### PR TITLE
feat: resize app

### DIFF
--- a/PeopleManager/Abstracts/ILocalizationService.cs
+++ b/PeopleManager/Abstracts/ILocalizationService.cs
@@ -1,4 +1,4 @@
-﻿namespace PeopleManager.Utils
+﻿namespace PeopleManager.Abstracts
 {
     public interface ILocalizationService
     {

--- a/PeopleManager/App.xaml.cs
+++ b/PeopleManager/App.xaml.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.Globalization;
-using PeopleManager.Utils;
+using PeopleManager.Abstracts;
+using PeopleManager.Common;
 using PeopleManager.ViewModels;
 using PeopleManager.Views;
 using Prism.Events;
 using System;
-//using System.Globalization;
 
 namespace PeopleManager
 {
@@ -21,9 +21,6 @@ namespace PeopleManager
             ConfigureServices();
             //ApplicationLanguages.PrimaryLanguageOverride = "en-US";
             ApplicationLanguages.PrimaryLanguageOverride = "pt-BR";
-
-            //CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("pt-BR");
-            //CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("pt-BR");
         }
 
         private void ConfigureServices()

--- a/PeopleManager/Common/DialogTemplate.cs
+++ b/PeopleManager/Common/DialogTemplate.cs
@@ -2,7 +2,7 @@
 using PeopleManager.Views.Organisms.ControlPages;
 using System;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     public static class DialogTemplate
     {

--- a/PeopleManager/Common/FormatData.cs
+++ b/PeopleManager/Common/FormatData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     static class FormatData
     {

--- a/PeopleManager/Common/GenerateCpf.cs
+++ b/PeopleManager/Common/GenerateCpf.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     static class GenerateCpf
     {

--- a/PeopleManager/Common/IdGenerator.cs
+++ b/PeopleManager/Common/IdGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     public class IdGenerator
     {

--- a/PeopleManager/Common/LocalizationService.cs
+++ b/PeopleManager/Common/LocalizationService.cs
@@ -1,6 +1,7 @@
-﻿using Windows.ApplicationModel.Resources;
+﻿using PeopleManager.Abstracts;
+using Windows.ApplicationModel.Resources;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     public class LocalizationService : ILocalizationService
     {

--- a/PeopleManager/Common/ResourceExtension.cs
+++ b/PeopleManager/Common/ResourceExtension.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.UI.Xaml.Markup;
-using Windows.ApplicationModel.Resources;
 using System;
+using Windows.ApplicationModel.Resources;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     public partial class ResourceExtension : MarkupExtension
     {

--- a/PeopleManager/Common/ThemeSettings.cs
+++ b/PeopleManager/Common/ThemeSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Windows.Storage;
 
-namespace PeopleManager.Utils
+namespace PeopleManager.Common
 {
     public static class ThemeSettings
     {

--- a/PeopleManager/Common/ValidateData.cs
+++ b/PeopleManager/Common/ValidateData.cs
@@ -1,4 +1,4 @@
-﻿namespace PeopleManager.Utils
+﻿namespace PeopleManager.Common
 {
     static class ValidateData
     {

--- a/PeopleManager/Common/WindowSizeManager.cs
+++ b/PeopleManager/Common/WindowSizeManager.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Windows.Graphics;
+
+namespace PeopleManager.Common
+{
+    public class WindowSizeManager
+    {
+        private readonly AppWindow appWindow;
+        private readonly int minWidth;
+        private readonly int minHeight;
+
+        public WindowSizeManager(Window window, int minWidth, int minHeight, int initialWidth, int initialHeight)
+        {
+            this.minWidth = minWidth;
+            this.minHeight = minHeight;
+
+            var windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            var windowId = Win32Interop.GetWindowIdFromWindow(windowHandle);
+            appWindow = AppWindow.GetFromWindowId(windowId);
+
+            SetInitialSize(initialWidth, initialHeight);
+            CenterWindow();
+            SetMinimumSize();
+        }
+
+        private void SetInitialSize(int width, int height)
+        {
+            var newSize = new SizeInt32 { Width = width, Height = height };
+            appWindow.Resize(newSize);
+        }
+
+        private void CenterWindow()
+        {
+            var displayArea = DisplayArea.GetFromWindowId(appWindow.Id, DisplayAreaFallback.Primary);
+            var workArea = displayArea.WorkArea;
+            var centerPosition = new RectInt32
+            {
+                X = (workArea.Width - appWindow.Size.Width) / 2,
+                Y = (workArea.Height - appWindow.Size.Height) / 2,
+                Width = appWindow.Size.Width,
+                Height = appWindow.Size.Height
+            };
+            appWindow.MoveAndResize(centerPosition);
+        }
+
+        private void SetMinimumSize()
+        {
+            appWindow.Changed += (sender, args) =>
+            {
+                if (args.DidSizeChange)
+                {
+                    var newSize = appWindow.Size;
+                    if (newSize.Width < minWidth || newSize.Height < minHeight)
+                    {
+                        appWindow.Resize(new SizeInt32
+                        {
+                            Width = newSize.Width < minWidth ? minWidth : newSize.Width,
+                            Height = newSize.Height < minHeight ? minHeight : newSize.Height
+                        });
+                    }
+                }
+            };
+        }
+    }
+}

--- a/PeopleManager/Events/ResizeComponents.cs
+++ b/PeopleManager/Events/ResizeComponents.cs
@@ -1,0 +1,16 @@
+﻿using Prism.Events;
+
+namespace PeopleManager.Events
+{
+    public enum Sizes { Infinity, ExtraLarge, Large, Medium, Small, ExtraSmall }
+    public enum HeightSizes { Large, Medium, Small }
+    public class Dimensions 
+    { 
+        public Sizes Size { get; set; } 
+        public HeightSizes HeightSize { get; set; } 
+        public int Width { get; set; } 
+        public int Height { get; set; } 
+    }
+
+    public class ResizeComponents : PubSubEvent<Dimensions> { }
+}

--- a/PeopleManager/Models/PersonManager.cs
+++ b/PeopleManager/Models/PersonManager.cs
@@ -1,5 +1,5 @@
-﻿using PeopleManager.Services;
-using PeopleManager.Utils;
+﻿using PeopleManager.Common;
+using PeopleManager.Services;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;

--- a/PeopleManager/PeopleManager.csproj
+++ b/PeopleManager/PeopleManager.csproj
@@ -22,6 +22,7 @@
     <None Remove="Views\Organisms\ControlPages\ContentDialogContent.xaml" />
     <None Remove="Views\Organisms\CustomTitleBar.xaml" />
     <None Remove="Views\Organisms\ControlPages\EditPersonDialog.xaml" />
+    <None Remove="Views\Organisms\TitleBar.xaml" />
     <None Remove="Views\PeopleView.xaml" />
   </ItemGroup>
 
@@ -52,6 +53,11 @@
   -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\Organisms\TitleBar.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\Organisms\ControlPages\ContentDialogContent.xaml">

--- a/PeopleManager/PeopleManager.csproj.user
+++ b/PeopleManager/PeopleManager.csproj.user
@@ -8,6 +8,9 @@
     <None Update="Package.appxmanifest">
       <SubType>Designer</SubType>
     </None>
+    <Page Update="Views\Organisms\TitleBar.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Update="Views\Organisms\ControlPages\ContentDialogContent.xaml">
       <SubType>Designer</SubType>
     </Page>

--- a/PeopleManager/Strings/en-US/Resources.resw
+++ b/PeopleManager/Strings/en-US/Resources.resw
@@ -159,6 +159,9 @@
   <data name="LabelFullName" xml:space="preserve">
     <value>Full Name</value>
   </data>
+  <data name="LabelRegisteredAt" xml:space="preserve">
+    <value>Registration Data</value>
+  </data>
   <data name="LabelSocialSecurityNumber" xml:space="preserve">
     <value>Social Security Number</value>
   </data>

--- a/PeopleManager/Strings/pt-BR/Resources.resw
+++ b/PeopleManager/Strings/pt-BR/Resources.resw
@@ -159,6 +159,9 @@
   <data name="LabelFullName" xml:space="preserve">
     <value>Nome Completo</value>
   </data>
+  <data name="LabelRegisteredAt" xml:space="preserve">
+    <value>Data de Cadastro</value>
+  </data>
   <data name="LabelSocialSecurityNumber" xml:space="preserve">
     <value>CPF</value>
   </data>

--- a/PeopleManager/Themes/ThemeResources.xaml
+++ b/PeopleManager/Themes/ThemeResources.xaml
@@ -6,6 +6,7 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
             <Color x:Key="BG-Window">#FFFFFF</Color>
+            <Color x:Key="BG-CaptionButton">#0D6EFD</Color>
             <Color x:Key="BG-Blue">#0D6EFD</Color>
             <Color x:Key="BG-PrimaryButton">#0D6EFD</Color>
             <Color x:Key="BG-SecondaryButton">#7D858C</Color>
@@ -38,6 +39,7 @@
 
         <ResourceDictionary x:Key="Dark">
             <Color x:Key="BG-Window">#212529</Color>
+            <Color x:Key="BG-CaptionButton">#212529</Color>
             <Color x:Key="BG-Blue">#DDD</Color>
             <Color x:Key="BG-PrimaryButton">#287EFD</Color>
             <Color x:Key="BG-SecondaryButton">#807D858C</Color>

--- a/PeopleManager/ViewModels/HeaderOrganismViewModel.cs
+++ b/PeopleManager/ViewModels/HeaderOrganismViewModel.cs
@@ -1,7 +1,8 @@
-﻿using PeopleManager.Events;
+﻿using PeopleManager.Abstracts;
+using PeopleManager.Common;
+using PeopleManager.Events;
 using PeopleManager.Models;
 using PeopleManager.Services;
-using PeopleManager.Utils;
 using Prism.Events;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/PeopleManager/Views/Atoms/ThemeToggle.xaml.cs
+++ b/PeopleManager/Views/Atoms/ThemeToggle.xaml.cs
@@ -1,6 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using PeopleManager.Utils;
+using PeopleManager.Common;
 
 namespace PeopleManager.Views.Atoms
 {

--- a/PeopleManager/Views/MainWindow.xaml
+++ b/PeopleManager/Views/MainWindow.xaml
@@ -11,14 +11,34 @@
     xmlns:resources="using:PeopleManager.Utils"
     x:Name="mainWindow"
     mc:Ignorable="d"
-    Title="{resources:ResourceExtension Key=AppTitle}">
+    SizeChanged="MainWindow_SizeChanged">
 
     <Grid Background="{ThemeResource BG-Window}">
         <Grid.RowDefinitions>
+            <RowDefinition Height="31"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
 
-        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+        <!--Title bar-->
+        <organisms:TitleBar 
+            x:Name="TitleBar" 
+            Grid.Row="0" />
+        <Grid 
+            x:Name="CaptionButtonBackground" 
+            Grid.Row="0" 
+            Grid.Column="1" 
+            Background="{ThemeResource BG-CaptionButton}" 
+            Width="138" />
+
+        <!--Main content-->
+        <ScrollViewer 
+            Grid.Row="2" 
+            Grid.ColumnSpan="2" 
+            VerticalScrollBarVisibility="Auto">
             <views:Home />
         </ScrollViewer>
     </Grid>

--- a/PeopleManager/Views/MainWindow.xaml.cs
+++ b/PeopleManager/Views/MainWindow.xaml.cs
@@ -1,34 +1,44 @@
-using Microsoft.UI;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using Windows.Graphics;
+using PeopleManager.Common;
+using PeopleManager.Events;
+using Prism.Events;
 
 namespace PeopleManager.Views
 {
     public partial class MainWindow : Window
     {
+        private readonly int MinWindowWidth = 780;
+        private readonly int MinWindowHeight = 650;
+        private readonly int InitialWidth = 1200;
+
         public MainWindow()
         {
             this.InitializeComponent();
-            CenterWindow();
+            this.ExtendsContentIntoTitleBar = true;
+            this.SetTitleBar(TitleBar);
+            _ = new WindowSizeManager(this, MinWindowWidth, MinWindowHeight, InitialWidth, MinWindowHeight);
         }
 
-        private void CenterWindow()
+
+        private void MainWindow_SizeChanged(object sender, WindowSizeChangedEventArgs e)
         {
-            var windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this); 
-            var windowId = Win32Interop.GetWindowIdFromWindow(windowHandle); 
-            var appWindow = AppWindow.GetFromWindowId(windowId); 
-            var displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary); 
-            var workArea = displayArea.WorkArea; 
-            var centerPosition = new RectInt32 
-            { 
-                X = (workArea.Width - appWindow.Size.Width) / 2, 
-                Y = (workArea.Height - appWindow.Size.Height) / 2, 
-                Width = appWindow.Size.Width, 
-                Height = appWindow.Size.Height 
-            }; 
-            appWindow.MoveAndResize(centerPosition);
+            var dimensions = new Dimensions
+            {
+                Width = (int)e.Size.Width,
+                Height = (int)e.Size.Height,
+                Size = GetWidthSize((int)e.Size.Width)
+            };
+            EventAggregator.Current.GetEvent<ResizeComponents>().Publish(dimensions);
         }
 
+        private static Sizes GetWidthSize(int width)
+        {
+            if (width > 1000) return Sizes.Infinity;
+            if (width > 800) return Sizes.ExtraLarge;
+            if (width > 600) return Sizes.Large;
+            if (width > 400) return Sizes.Medium;
+            if (width > 200) return Sizes.Small;
+            return Sizes.ExtraSmall;
+        }
     }
 }

--- a/PeopleManager/Views/Molecules/RegisterForm.xaml.cs
+++ b/PeopleManager/Views/Molecules/RegisterForm.xaml.cs
@@ -1,9 +1,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
-using PeopleManager.Utils;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+using PeopleManager.Common;
 
 namespace PeopleManager.Views.Molecules
 {

--- a/PeopleManager/Views/Organisms/BaseForm.xaml
+++ b/PeopleManager/Views/Organisms/BaseForm.xaml
@@ -2,11 +2,10 @@
 <UserControl
     x:Class="PeopleManager.Views.Organisms.BaseForm"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:PeopleManager.Views.Organisms"
-    xmlns:resources="using:PeopleManager.Utils"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resource="using:PeopleManager.Common"
     mc:Ignorable="d">
 
     <StackPanel 
@@ -26,19 +25,19 @@
                  x:Name="NameFieldTxb"
                  Margin="0,5,0,5"
                  MaxLength="15"
-                 PlaceholderText="{resources:ResourceExtension Key=PlaceholderName}"
+                 PlaceholderText="{resource:ResourceExtension Key=PlaceholderName}"
                  Text="{x:Bind NameField, Mode=TwoWay}" />
         <TextBox
                  x:Name="SurnameFieldTxb"
                  Margin="0,5,0,5"
                  MaxLength="15"
-                 PlaceholderText="{resources:ResourceExtension Key=PlaceholderLastName}"
+                 PlaceholderText="{resource:ResourceExtension Key=PlaceholderLastName}"
                  Text="{x:Bind SurnameField, Mode=TwoWay}" />
         <TextBox
                  x:Name="CpfFieldTxb"
                  Margin="0,5,0,5"
                  MaxLength="11"
-                 PlaceholderText="{resources:ResourceExtension Key=PlaceholderSocialSecurityNumber}"
+                 PlaceholderText="{resource:ResourceExtension Key=PlaceholderSocialSecurityNumber}"
                  Text="{x:Bind CpfField, Mode=TwoWay}"
                  KeyUp="FormatCpf_KeyUp"/>
         <Grid>
@@ -47,7 +46,7 @@
                     Foreground="{ThemeResource Color-WhiteButton}"
                     Background="{ThemeResource BG-SecondaryButton}"
                     Visibility="{x:Bind ButtonLeftVisibility, Mode=TwoWay}" 
-                    Content="{resources:ResourceExtension Key=ClearButton}"
+                    Content="{resource:ResourceExtension Key=ClearButton}"
                     Command="{x:Bind ButtonLeftCommand}"/>
             <Button
                  x:Name="BtnSend"

--- a/PeopleManager/Views/Organisms/BaseForm.xaml.cs
+++ b/PeopleManager/Views/Organisms/BaseForm.xaml.cs
@@ -1,6 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using PeopleManager.Utils;
+using PeopleManager.Common;
 using System;
 using System.Windows.Input;
 

--- a/PeopleManager/Views/Organisms/ControlPages/EditPersonDialog.xaml
+++ b/PeopleManager/Views/Organisms/ControlPages/EditPersonDialog.xaml
@@ -2,15 +2,14 @@
 <ContentDialog
     x:Class="PeopleManager.Views.Organisms.ControlPages.EditPersonDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:PeopleManager.Views.Organisms.ControlPages"
-    xmlns:resources="using:PeopleManager.Utils"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resource="using:PeopleManager.Common"
     mc:Ignorable="d"
-    Title="{resources:ResourceExtension Key=EditDialogTitle}"
-    PrimaryButtonText="{resources:ResourceExtension Key=UpdateButton}"
-    CloseButtonText="{resources:ResourceExtension Key=CancelButton}">
+    Title="{resource:ResourceExtension Key=EditDialogTitle}"
+    PrimaryButtonText="{resource:ResourceExtension Key=UpdateButton}"
+    CloseButtonText="{resource:ResourceExtension Key=CancelButton}">
     
     <Grid>
         <StackPanel>

--- a/PeopleManager/Views/Organisms/ControlPages/EditPersonDialog.xaml.cs
+++ b/PeopleManager/Views/Organisms/ControlPages/EditPersonDialog.xaml.cs
@@ -1,5 +1,5 @@
 using Microsoft.UI.Xaml.Controls;
-using PeopleManager.Utils;
+using PeopleManager.Common;
 
 namespace PeopleManager.Views.Organisms.ControlPages
 {

--- a/PeopleManager/Views/Organisms/Footer.xaml
+++ b/PeopleManager/Views/Organisms/Footer.xaml
@@ -2,11 +2,10 @@
 <UserControl
     x:Class="PeopleManager.Views.Organisms.Footer"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:PeopleManager.Views.Organisms"
-    xmlns:resources="using:PeopleManager.Utils"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resource="using:PeopleManager.Common"
     mc:Ignorable="d">
 
     <StackPanel
@@ -27,7 +26,7 @@
 
             <StackPanel Grid.Column="0" Orientation="Horizontal">
                 <TextBlock 
-                    Text="{resources:ResourceExtension Key=DevelopedBy}" 
+                    Text="{resource:ResourceExtension Key=DevelopedBy}" 
                     Foreground="{ThemeResource Color-Dark}" 
                     FontWeight="SemiBold"
                     Padding="5" />

--- a/PeopleManager/Views/Organisms/HeaderOrganism.xaml
+++ b/PeopleManager/Views/Organisms/HeaderOrganism.xaml
@@ -2,12 +2,12 @@
 <UserControl
     x:Class="PeopleManager.Views.Organisms.HeaderOrganism"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:PeopleManager.Views.Organisms"
-    xmlns:atom="using:PeopleManager.Views.Atoms"
-    xmlns:resources="using:PeopleManager.Utils"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resource="using:PeopleManager.Common"
+    xmlns:atom="using:PeopleManager.Views.Atoms"
+    xmlns:local="using:PeopleManager.Views.Organisms"
     mc:Ignorable="d">
 
     <Grid
@@ -19,7 +19,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
+            <!--<ColumnDefinition Width="*" />-->
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
@@ -27,8 +27,8 @@
 
         <local:BaseForm
             x:Name="RegisterForm"
-            FormTitle="{resources:ResourceExtension Key=RegisterTitle}" 
-            ButtonContent="{resources:ResourceExtension Key=RegisterButton}"
+            FormTitle="{resource:ResourceExtension Key=RegisterTitle}" 
+            ButtonContent="{resource:ResourceExtension Key=RegisterButton}"
             NameField="{Binding RegisterName, Mode=TwoWay}"
             SurnameField="{Binding RegisterSurname, Mode=TwoWay}"
             CpfField="{Binding RegisterCpf, Mode=TwoWay}"
@@ -38,8 +38,8 @@
         
         <local:BaseForm
             x:Name="FilterForm"
-            FormTitle="{resources:ResourceExtension Key=FilterTitle}" 
-            ButtonContent="{resources:ResourceExtension Key=FilterButton}"
+            FormTitle="{resource:ResourceExtension Key=FilterTitle}" 
+            ButtonContent="{resource:ResourceExtension Key=FilterButton}"
             NameField="{Binding FilterName, Mode=TwoWay}"
             SurnameField="{Binding FilterSurname, Mode=TwoWay}"
             CpfField="{Binding FilterCpf, Mode=TwoWay}"
@@ -47,10 +47,11 @@
             ButtonLeftCommand="{Binding ClearFilterButtonCommand}"
             ButtonRightCommand="{Binding FilterPersonCommand}" 
             Grid.Column="1" />
-        
-        <local:OrderPeople x:Name="SortPeople" Grid.Column="2" />
-             
-        <atom:ThemeToggle Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Top" />
+
+        <StackPanel Grid.Column="2" x:Name="SortAndToggleStackPanel" Orientation="Horizontal" Spacing="10">
+            <local:OrderPeople x:Name="SortPeople" HorizontalAlignment="Right" />
+            <atom:ThemeToggle HorizontalAlignment="Left" VerticalAlignment="Top" />
+        </StackPanel>
         
     </Grid>
 </UserControl>

--- a/PeopleManager/Views/Organisms/HeaderOrganism.xaml.cs
+++ b/PeopleManager/Views/Organisms/HeaderOrganism.xaml.cs
@@ -1,5 +1,7 @@
 using Microsoft.UI.Xaml.Controls;
+using PeopleManager.Events;
 using PeopleManager.ViewModels;
+using Prism.Events;
 
 namespace PeopleManager.Views.Organisms
 {
@@ -11,6 +13,22 @@ namespace PeopleManager.Views.Organisms
             this.InitializeComponent();
             viewModel = App.GetService<HeaderOrganismViewModel>();
             DataContext = viewModel;
+            EventAggregator.Current.GetEvent<ResizeComponents>().Subscribe(ResizeHeader);
+        }
+
+        private void ResizeHeader(Dimensions dimensions)
+        {
+            switch(dimensions.Size)
+            {
+                case Sizes.Infinity:
+                    SortAndToggleStackPanel.Orientation = Orientation.Horizontal;
+                    break;
+                case Sizes.ExtraLarge:
+                    SortAndToggleStackPanel.Orientation = Orientation.Vertical;
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/PeopleManager/Views/Organisms/OrderPeople.xaml
+++ b/PeopleManager/Views/Organisms/OrderPeople.xaml
@@ -5,29 +5,28 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:PeopleManager.Views.Organisms"
-    xmlns:resources="using:PeopleManager.Utils"
+    xmlns:resource="using:PeopleManager.Common"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
     <StackPanel
         x:Name="GridHeaderOrdination"
         Grid.Column="2"
-        Width="200"
         Margin="0,0,20,0"
         Orientation="Vertical">
         <TextBlock 
-            Text="{resources:ResourceExtension Key=SortTitle}"
+            Text="{resource:ResourceExtension Key=SortTitle}"
             Foreground="{ThemeResource Color-Blue}" 
             Style="{StaticResource SubtitleTextBlockStyle}" />
         <ComboBox
             x:Name="ComboBoxOrdination"
             Width="200"
             Margin="0,5,0,0"
-            PlaceholderText="{resources:ResourceExtension Key=PlaceholderSortBy}"
+            PlaceholderText="{resource:ResourceExtension Key=PlaceholderSortBy}"
             SelectionChanged="Ordination_Changed">
-            <ComboBoxItem Content="{resources:ResourceExtension Key=PlaceholderDefault}" />
-            <ComboBoxItem Content="{resources:ResourceExtension Key=PlaceholderName}" />
-            <ComboBoxItem Content="{resources:ResourceExtension Key=PlaceholderLastName}" />
+            <ComboBoxItem Content="{resource:ResourceExtension Key=PlaceholderDefault}" />
+            <ComboBoxItem Content="{resource:ResourceExtension Key=PlaceholderName}" />
+            <ComboBoxItem Content="{resource:ResourceExtension Key=PlaceholderLastName}" />
         </ComboBox>
     </StackPanel>
 </UserControl>

--- a/PeopleManager/Views/Organisms/PeopleList.xaml
+++ b/PeopleManager/Views/Organisms/PeopleList.xaml
@@ -2,11 +2,10 @@
 <UserControl
     x:Class="PeopleManager.Views.Organisms.PeopleList"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:PeopleManager.Views.Organisms"
-    xmlns:resources="using:PeopleManager.Utils"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resource="using:PeopleManager.Common"
     mc:Ignorable="d">
 
     <!--<UserControl.Resources>
@@ -35,28 +34,37 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="350*" MinWidth="200" />
                 <ColumnDefinition Width="200*" MinWidth="150" />
+                <ColumnDefinition Width="200*" MinWidth="150" />
                 <ColumnDefinition Width="250*" MinWidth="200" />
             </Grid.ColumnDefinitions>
 
             <TextBlock 
-                Text="{resources:ResourceExtension Key=LabelFullName}" 
+                Grid.Column="0"
+                Text="{resource:ResourceExtension Key=LabelFullName}" 
                 Foreground="{ThemeResource Color-Dark}"
-                Margin="0,0,5,0" 
-                Grid.Column="0" 
+                Margin="0,0,5,0"  
                 Padding="5"
                 FontWeight="SemiBold" />
             <TextBlock 
-                Text="{resources:ResourceExtension Key=LabelSocialSecurityNumber}" 
-                Foreground="{ThemeResource Color-Dark}"
-                Padding="5"
-                Margin="0,0,5,0" 
                 Grid.Column="1"
-                FontWeight="SemiBold" />
-            <TextBlock 
-                Text="{resources:ResourceExtension Key=LabelActions}" 
+                Text="{resource:ResourceExtension Key=LabelSocialSecurityNumber}" 
                 Foreground="{ThemeResource Color-Dark}"
                 Padding="5"
-                Margin="0,0,5,0" Grid.Column="2"
+                Margin="0,0,5,0" 
+                FontWeight="SemiBold" />
+            <TextBlock 
+                Grid.Column="2"
+                Text="{resource:ResourceExtension Key=LabelRegisteredAt}" 
+                Foreground="{ThemeResource Color-Dark}"
+                Padding="5"
+                Margin="0,0,5,0" 
+                FontWeight="SemiBold" />
+            <TextBlock 
+                Grid.Column="3"
+                Text="{resource:ResourceExtension Key=LabelActions}" 
+                Foreground="{ThemeResource Color-Dark}"
+                Padding="5"
+                Margin="0,0,5,0"
                 HorizontalTextAlignment="Center" 
                 FontWeight="SemiBold" />
         </Grid>
@@ -74,6 +82,7 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="350*" MinWidth="200" />
                                     <ColumnDefinition Width="200*" MinWidth="150" />
+                                    <ColumnDefinition Width="200*" MinWidth="150" />
                                     <ColumnDefinition Width="250*" MinWidth="200" />
                                 </Grid.ColumnDefinitions>
 
@@ -90,18 +99,25 @@
                                     Padding="5"
                                     VerticalAlignment="Center" />
 
-                                <StackPanel Orientation="Horizontal" Grid.Column="2" HorizontalAlignment="Center">
+                                <TextBlock 
+                                    Grid.Column="2" 
+                                    Text="{Binding RegisteredAt}" 
+                                    Foreground="{ThemeResource Color-White}"
+                                    Padding="5"
+                                    VerticalAlignment="Center" />
+
+                                <StackPanel Orientation="Horizontal" Grid.Column="3" HorizontalAlignment="Center">
                                     <Button x:Name="EditPerson" 
                                             Tag="{Binding}" 
                                             Foreground="{ThemeResource Color-Black}"
                                             Background="{ThemeResource BG-Warning}"
                                             FontWeight="SemiBold"
                                             Margin="2"
-                                            AutomationProperties.Name="{resources:ResourceExtension Key=EditButtonList}"
+                                            AutomationProperties.Name="{resource:ResourceExtension Key=EditButtonList}"
                                             Click="EditPerson_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <SymbolIcon Symbol="Edit" Margin="0,0,5,0" />
-                                            <TextBlock Text="{resources:ResourceExtension Key=EditButtonList}"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="5">
+                                            <FontIcon Glyph="&#xE70F;" />
+                                            <TextBlock Text="{resource:ResourceExtension Key=EditButtonList}"/>
                                         </StackPanel>
                                     </Button>
                                     
@@ -111,11 +127,12 @@
                                             Background="{ThemeResource BG-Danger}"
                                             FontWeight="SemiBold"
                                             Margin="2"
-                                            AutomationProperties.Name="{resources:ResourceExtension Key=DeleteButtonList}" 
+                                            AutomationProperties.Name="{resource:ResourceExtension Key=DeleteButtonList}" 
                                             Click="DeletePerson_Click">
-                                        <StackPanel Orientation="Horizontal">
-                                            <SymbolIcon Symbol="Delete" Margin="0,0,5,0" />
-                                            <TextBlock Text="{resources:ResourceExtension Key=DeleteButtonList}"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="5">
+                                            <!--<SymbolIcon Symbol="Delete" />-->
+                                            <FontIcon Glyph="&#xE74D;" />
+                                            <TextBlock Text="{resource:ResourceExtension Key=DeleteButtonList}"/>
                                         </StackPanel>
                                     </Button>
                                 </StackPanel>

--- a/PeopleManager/Views/Organisms/PeopleList.xaml.cs
+++ b/PeopleManager/Views/Organisms/PeopleList.xaml.cs
@@ -1,8 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using PeopleManager.Common;
 using PeopleManager.Events;
 using PeopleManager.Models;
-using PeopleManager.Utils;
 using PeopleManager.ViewModels;
 using PeopleManager.Views.Organisms.ControlPages;
 using Prism.Events;
@@ -38,7 +38,7 @@ namespace PeopleManager.Views.Organisms
             {
                 DialogTemplate.ShowDialog(this.XamlRoot, resourceLoader.GetString("EmptyFieldsDialogMessage"));
             } 
-            else if (!string.IsNullOrEmpty(Name) || !string.IsNullOrEmpty(SurName) || !string.IsNullOrEmpty(CPF))
+            if (!string.IsNullOrEmpty(Name) || !string.IsNullOrEmpty(SurName) || !string.IsNullOrEmpty(CPF))
             {
                 var filteredPerson = peopleList.Where(p =>
                 (string.IsNullOrWhiteSpace(Name) || p.Name.StartsWith(Name, StringComparison.CurrentCultureIgnoreCase)) &&
@@ -125,6 +125,5 @@ namespace PeopleManager.Views.Organisms
                     EventAggregator.Current.GetEvent<UpdatePersonEvent>().Publish(editedPerson);
             }
         }
-
     }
 }

--- a/PeopleManager/Views/Organisms/TitleBar.xaml
+++ b/PeopleManager/Views/Organisms/TitleBar.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="PeopleManager.Views.Organisms.TitleBar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:PeopleManager.Views.Organisms"
+    xmlns:resource="using:PeopleManager.Common"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    
+    <StackPanel 
+        Background="{ThemeResource BG-Window}"
+        Height="30"
+        Padding="15,0"
+        Orientation="Horizontal">
+        <ImageIcon Source="ms-appx:///Assets/Dtafalonso-Win-10x-People.48.png" Width="20" Height="20" Margin="5"/>
+        <TextBlock Text="{resource:ResourceExtension Key=AppTitle}" VerticalAlignment="Center" Margin="5"/>
+    </StackPanel>
+</UserControl>

--- a/PeopleManager/Views/Organisms/TitleBar.xaml.cs
+++ b/PeopleManager/Views/Organisms/TitleBar.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace PeopleManager.Views.Organisms
+{
+    public sealed partial class TitleBar : UserControl
+    {
+        public TitleBar()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
The background of the buttons (Min, Max and close) can be styled by native methods using `Window.Current.AppWindow.TitleBar.ButtonBackgroundColor = color;`
The same can be applied to the icon color: `ButtonForegroundColor`.

----
Centering and Setting initial size

```c#
       SetInitialSize(1200, MinWindowHeight);
       CenterWindow();

        private void CenterWindow()
        {
            var windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
            var windowId = Win32Interop.GetWindowIdFromWindow(windowHandle);
            var appWindow = AppWindow.GetFromWindowId(windowId);
            var displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary);
            var workArea = displayArea.WorkArea;
            var centerPosition = new RectInt32
            {
                X = (workArea.Width - appWindow.Size.Width) / 2,
                Y = (workArea.Height - appWindow.Size.Height) / 2,
                Width = appWindow.Size.Width,
                Height = appWindow.Size.Height
            };
            appWindow.MoveAndResize(centerPosition);
        }

        private void SetInitialSize(int width, int height)
        {
            var windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
            var windowId = Win32Interop.GetWindowIdFromWindow(windowHandle);
            var appWindow = AppWindow.GetFromWindowId(windowId);
            var newSize = new Windows.Graphics.SizeInt32 { Width = width, Height = height };
            appWindow.Resize(newSize);
        }
```